### PR TITLE
release: Xmind 26.02.04172

### DIFF
--- a/net.xmind.XMind.json
+++ b/net.xmind.XMind.json
@@ -42,15 +42,15 @@
       "sources": [
         {
           "type": "file",
-          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-amd64bit-26.01.03145-202510170359.deb",
-          "sha256": "87bab10dfdb5f7eb7ca0093c20006ceccc9ab0d7772bf3c033a6bbf64c9a2ddc",
+          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-amd64bit-26.02.04172-202604081834.deb",
+          "sha256": "27dacf64ec9cdb21803fe589dec0471ba172dfba47e86a7df58f39b71c7b0eb7",
           "dest-filename": "xmind.deb",
           "only-arches": ["x86_64"]
         },
         {
           "type": "file",
-          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-arm64bit-26.01.03145-202510192005.deb",
-          "sha256": "58b386d7a8730a6a97f6299b692b6130f63b67c1ac6220e24844ac37159fa4f3",
+          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-arm64bit-26.02.04172-202604121808.deb",
+          "sha256": "f531c0806b935148f17a8ec5e36f2d8e2464bac992337026062ec077ddeaab40",
           "dest-filename": "xmind.deb",
           "only-arches": ["aarch64"]
         },

--- a/net.xmind.XMind.metainfo.xml
+++ b/net.xmind.XMind.metainfo.xml
@@ -44,6 +44,7 @@
 		</screenshot>
 	</screenshots>
 	<releases>
+		<release version="26.02.04172" date="2026-04-13"/>
 		<release version="26.01.03145" date="2025-10-21"/>
 		<release version="25.04.03033" date="2025-05-13"/>
 		<release version="24.10.01101" date="2024-10-22"/>


### PR DESCRIPTION
## Changes
- Updated Xmind to v26.02.04172

## Sources
- amd64: `Xmind-for-Linux-amd64bit-26.02.04172-202604081834.deb`
- arm64: `Xmind-for-Linux-arm64bit-26.02.04172-202604121808.deb`