### PR TITLE
release: Xmind 26.02.04172

### DIFF
--- a/net.xmind.XMind.json
+++ b/net.xmind.XMind.json
@@ -42,15 +42,15 @@
       "sources": [
         {
           "type": "file",
-          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-amd64bit-26.01.03145-202510170359.deb",
-          "sha256": "87bab10dfdb5f7eb7ca0093c20006ceccc9ab0d7772bf3c033a6bbf64c9a2ddc",
+          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-amd64bit-26.02.04172-202604081834.deb",
+          "sha256": "27dacf64ec9cdb21803fe589dec0471ba172dfba47e86a7df58f39b71c7b0eb7",
           "dest-filename": "xmind.deb",
           "only-arches": ["x86_64"]
         },
         {
           "type": "file",
-          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-arm64bit-26.01.03145-202510192005.deb",
-          "sha256": "58b386d7a8730a6a97f6299b692b6130f63b67c1ac6220e24844ac37159fa4f3",
+          "url": "https://xmind.app/xmind/downloads/Xmind-for-Linux-arm64bit-26.02.04172-202604121808.deb",
+          "sha256": "f531c0806b935148f17a8ec5e36f2d8e2464bac992337026062ec077ddeaab40",
           "dest-filename": "xmind.deb",
           "only-arches": ["aarch64"]
         },

--- a/net.xmind.XMind.metainfo.xml
+++ b/net.xmind.XMind.metainfo.xml
@@ -44,6 +44,7 @@
 		</screenshot>
 	</screenshots>
 	<releases>
+		<release version="26.02.04172" date="2026-04-13"/>
 		<release version="26.01.03145" date="2025-10-21"/>
 		<release version="25.04.03033" date="2025-05-13"/>
 		<release version="24.10.01101" date="2024-10-22"/>

--- a/net.xmind.XMind.metainfo.xml
+++ b/net.xmind.XMind.metainfo.xml
@@ -22,24 +22,31 @@
 	<update_contact>xmind-2025_AT_xmind.app</update_contact>
 	<screenshots>
 		<screenshot type="default">
+			<caption>Full-featured Mind Mapping</caption>
 			<image>https://assets.xmind.net/uploads/img/017db1649c9fe2bb9e6d20d49de1607e13.png</image>
 		</screenshot>
 		<screenshot>
+			<caption>Capture Ideas from Brainstorming</caption>
 			<image>https://assets.xmind.net/uploads/img/0282e618e8998d5420c0922544b6fa4c19.png</image>
 		</screenshot>
 		<screenshot>
+			<caption>Become a Great Storyteller</caption>
 			<image>https://assets.xmind.net/uploads/img/03442957d493b47f50fca2ced35cd2ce3d.png</image>
 		</screenshot>
 		<screenshot>
+			<caption>Smart Color Theme</caption>
 			<image>https://assets.xmind.net/uploads/img/041db1e67d6471db6d1bdd202c9e65295b.png</image>
 		</screenshot>
 		<screenshot>
+			<caption>Hand-Drawn Style</caption>
 			<image>https://assets.xmind.net/uploads/img/05f2ada9a4cc15be64e3c306e2f84cbf0d.png</image>
 		</screenshot>
 		<screenshot>
+			<caption>Stickers and Illustrations</caption>
 			<image>https://assets.xmind.net/uploads/img/066aaabcf5a025b66486196b438fc0049c.png</image>
 		</screenshot>
 		<screenshot>
+			<caption>Ideas Grow On Trees</caption>
 			<image>https://assets.xmind.net/uploads/img/0716b3368df018c43448c2219524d34245.png</image>
 		</screenshot>
 	</screenshots>


### PR DESCRIPTION
## Changes
- Updated Xmind to v26.02.04172
- Added captions to screenshots in metainfo.xml to resolve `appstream-screenshot-missing-caption` linter warning. Caption text is taken from the headline text displayed on each screenshot image.

## Sources
- amd64: `Xmind-for-Linux-amd64bit-26.02.04172-202604081834.deb`
- arm64: `Xmind-for-Linux-arm64bit-26.02.04172-202604121808.deb`

@XRenSiu 